### PR TITLE
Add CA certificates to support HTTPS backends.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /go/src/github.com/devsisters && \
 	rm -rf /go && \
 	apk del build-deps 
 
-RUN apk add --no-cache libstdc++ libgcc
+RUN apk add --no-cache libstdc++ libgcc ca-certificates
 
 ENTRYPOINT ["/usr/goquic/reverse_proxy"]
 CMD ["--help"]


### PR DESCRIPTION
Really useful lightweight container! This adds support for HTTPS backends and fixes this error:

```http: proxy error: x509: failed to load system roots and no roots provided```